### PR TITLE
add dynamic expiration of tokens

### DIFF
--- a/src/pyramid_jwt/__init__.py
+++ b/src/pyramid_jwt/__init__.py
@@ -35,8 +35,8 @@ def set_jwt_authentication_policy(config, private_key=None, public_key=None,
             auth_type=auth_type,
             callback=callback)
 
-    def request_create_token(request, principal):
-            return policy.create_token(principal)
+    def request_create_token(request, principal, expiration=None):
+            return policy.create_token(principal, expiration)
 
     config.set_authentication_policy(policy)
     config.add_request_method(request_create_token, 'create_jwt_token')

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -31,12 +31,15 @@ class JWTAuthenticationPolicy(CallbackAuthenticationPolicy):
             self.expiration = None
         self.callback = callback
 
-    def create_token(self, principal):
+    def create_token(self, principal, expiration=None):
         payload = self.default_claims.copy()
         payload['sub'] = principal
         payload['iat'] = iat = datetime.datetime.utcnow()
-        if self.expiration:
-            payload['exp'] = iat + self.expiration
+        expiration = expiration or self.expiration
+        if expiration:
+            if not isinstance(expiration, datetime.timedelta):
+                    expiration = datetime.timedelta(seconds=expiration)
+            payload['exp'] = iat + expiration
         token = jwt.encode(payload, self.private_key, algorithm=self.algorithm)
         if not isinstance(token, str):  # Python3 unicode madness
             token = token.decode('ascii')

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -57,6 +57,19 @@ def test_expired_token():
     assert policy.unauthenticated_userid(request) == 15
 
 
+def test_dynamic_expired_token():
+    policy = JWTAuthenticationPolicy('secret', expiration=-1)
+    request = Request.blank('/')
+    request.authorization = ('JWT', policy.create_token(15, expiration=5))
+    assert policy.unauthenticated_userid(request) == 15
+
+    policy = JWTAuthenticationPolicy('secret')
+    request.authorization = ('JWT', policy.create_token(15, expiration=-1))
+    assert policy.unauthenticated_userid(request) is None
+    request.authorization = ('JWT', policy.create_token(15))
+    assert policy.unauthenticated_userid(request) == 15
+
+
 def test_remember_warning():
     policy = JWTAuthenticationPolicy('secret', http_header='X-Token')
     with testConfig() as config:


### PR DESCRIPTION
In our api the user can define the expiration time of the token himself
by passing an `expiration` parameter along the usual `user`/`password`.
