### PR TITLE
Add option to define custom json_encoder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,3 +138,6 @@ You can either set this in your .ini-file, or pass/override them directly to the
 | auth_type    | jwt.auth_type   | JWT           | Authentication type used in Authorization  |
 |              |                 |               | header. Unused for other HTTP headers.     |
 +--------------+-----------------+---------------+--------------------------------------------+
+| json_encoder | -               | None          | A subclass of JSONEncoder to be used       |
+|              |                 |               | to encode principal and claims infos.      |
++--------------+-----------------+---------------+--------------------------------------------+

--- a/src/pyramid_jwt/__init__.py
+++ b/src/pyramid_jwt/__init__.py
@@ -10,7 +10,7 @@ def includeme(config):
 
 def create_jwt_authentication_policy(config, private_key=None, public_key=None,
         algorithm=None, expiration=None, leeway=None,
-        http_header=None, auth_type=None, callback=None):
+        http_header=None, auth_type=None, callback=None, json_encoder=None):
     settings = config.get_settings()
     private_key = private_key or settings.get('jwt.private_key')
     algorithm = algorithm or settings.get('jwt.algorithm') or 'HS512'
@@ -34,16 +34,17 @@ def create_jwt_authentication_policy(config, private_key=None, public_key=None,
             expiration=expiration,
             http_header=http_header,
             auth_type=auth_type,
-            callback=callback)
+            callback=callback,
+            json_encoder=json_encoder)
 
 
 def set_jwt_authentication_policy(config, private_key=None, public_key=None,
         algorithm=None, expiration=None, leeway=None,
-        http_header=None, auth_type=None, callback=None):
+        http_header=None, auth_type=None, callback=None, json_encoder=None):
     policy = create_jwt_authentication_policy(
             config, private_key, public_key,
             algorithm, expiration, leeway,
-            http_header, auth_type, callback)
+            http_header, auth_type, callback, json_encoder)
 
     def request_create_token(request, principal, expiration=None, **claims):
         return policy.create_token(principal, expiration, **claims)

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -15,7 +15,7 @@ class JWTAuthenticationPolicy(CallbackAuthenticationPolicy):
     def __init__(self, private_key, public_key=None, algorithm='HS512',
             leeway=0, expiration=None, default_claims=None,
             http_header='Authorization', auth_type='JWT',
-            callback=None):
+            callback=None, json_encoder=None):
         self.private_key = private_key
         self.public_key = public_key if public_key is not None else private_key
         self.algorithm = algorithm
@@ -30,6 +30,7 @@ class JWTAuthenticationPolicy(CallbackAuthenticationPolicy):
         else:
             self.expiration = None
         self.callback = callback
+        self.json_encoder = json_encoder
 
     def create_token(self, principal, expiration=None, **claims):
         payload = self.default_claims.copy()
@@ -41,7 +42,7 @@ class JWTAuthenticationPolicy(CallbackAuthenticationPolicy):
             if not isinstance(expiration, datetime.timedelta):
                     expiration = datetime.timedelta(seconds=expiration)
             payload['exp'] = iat + expiration
-        token = jwt.encode(payload, self.private_key, algorithm=self.algorithm)
+        token = jwt.encode(payload, self.private_key, algorithm=self.algorithm, json_encoder=self.json_encoder)
         if not isinstance(token, str):  # Python3 unicode madness
             token = token.decode('ascii')
         return token


### PR DESCRIPTION
New option to specify a custom json encoder. 
Can be useful when the claim value or principal could not be encoded by the default json encoder (example : uuid)