### PR TITLE
correctly use the jwt api, using the 'algorithms' keyword

### DIFF
--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -62,7 +62,7 @@ class JWTAuthenticationPolicy(CallbackAuthenticationPolicy):
         if not token:
             return {}
         try:
-            claims = jwt.decode(token, self.public_key, algorithm=[self.algorithm], leeway=self.leeway)
+            claims = jwt.decode(token, self.public_key, algorithms=[self.algorithm], leeway=self.leeway)
         except jwt.InvalidTokenError as e:
             log.warning('Invalid JWT token from %s: %s', request.remote_addr, e)
             return {}


### PR DESCRIPTION
As seen here:
https://github.com/jpadilla/pyjwt/blob/master/jwt/api_jwt.py#L59
The keyword arg should be 'algorithms' (plural). Noticed from the deprecation warning.