### PR TITLE
JWT tokens inside Cookies

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -e .[testing]
-          python -m pip install pytest
 
       - name: Run tests
         run: py.test

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ deletion mechanism respected by most browsers, so a call to Pyramid's
 ``forget()`` function will instruct the browser remove that cookie, effectively
 throwing that JWT token away, even though it may still be valid.
 
-See :ref:`_cookie_examples` for examples.
+See `Creating a JWT within a cookie`_ for examples.
 
 Extra claims
 ------------
@@ -385,8 +385,8 @@ security backend, we need to also add the following to __init__.py:
 This code will map any properties of the "roles" attribute of the JWT, run them
 through the ACL and then tie them into pyramids security framework.
 
-.. _cookie_examples: Creating a JWT within a cookie
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Creating a JWT within a cookie
+------------------------------
 
 Since cookie-based authentication is already standardized within Pyramid by the
 ``remember()`` and ``forget()`` calls, you should simply use them:

--- a/README.rst
+++ b/README.rst
@@ -60,10 +60,50 @@ authentication view for a REST backend could look something like this:
                 'result': 'error'
             }
 
-Since JWT is typically used via HTTP headers and does not use cookies the
+Unless you are using JWT cookies within cookies (see the next section), the
 standard ``remember()`` and ``forget()`` functions from Pyramid are not useful.
-Trying to use them while JWT authentication is enabled will result in a warning.
+Trying to use them while regular (header-based) JWT authentication is enabled
+will result in a warning.
 
+Using JWT inside cookies
+------------------------
+
+Optionally, you can use cookies as a transport for the JWT Cookies. This is an
+useful technique to allow browser-based web apps to consume your REST APIs
+without the hassle of managing token storage (where to store JWT cookies is a
+known-issue), since ``http_only`` cookies cannot be handled by Javascript
+running on the page
+
+Using JWT within cookies have some added benefits, the first one being *sliding
+sessions*: Tokens inside cookies will automatically be reissued whenever
+``reissue_time`` is past.
+
+.. code-block:: python
+
+   from pyramid.config import Configurator
+   from pyramid.authorization import ACLAuthorizationPolicy
+
+   def main():
+       config = Configurator()
+       # Pyramid requires an authorization policy to be active.
+       config.set_authorization_policy(ACLAuthorizationPolicy())
+       # Enable JWT authentication.
+       config.include('pyramid_jwt')
+       config.set_jwt_cookie_authentication_policy(
+           'secret', reissue_time=7200
+       )
+
+When working with JWT alone, there's no standard for manually invalidating a
+token: Either the token validity expires, or the application needs to handle a
+token blacklist (or even better, a whitelist)
+
+On the other hand, when using cookies, this library allows the app to *logout*
+a given user by erasing its cookie: This policy follows the standard cookie
+deletion mechanism respected by most browsers, so a call to Pyramid's
+``forget()`` function will instruct the browser remove that cookie, effectively
+throwing that JWT token away, even though it may still be valid.
+
+See :ref:`_cookie_examples` for examples.
 
 Extra claims
 ------------
@@ -180,6 +220,21 @@ You can either set this in your .ini-file, or pass/override them directly to the
 | json_encoder |                 | None          | A subclass of JSONEncoder to be used       |
 |              |                 |               | to encode principal and claims infos.      |
 +--------------+-----------------+---------------+--------------------------------------------+
+
+The follow options applies to the cookie-based authentication policy:
+
++----------------+---------------------------+---------------+--------------------------------------------+
+| Parameter      | ini-file entry            | Default       | Description                                |
++================+===========================+===============+============================================+
+| cookie_name    | jwt.cookie_name           | Authorization | Key used to identify the cookie.           |
++----------------+---------------------------+---------------+--------------------------------------------+
+| https_only     | jwt.https_only_cookie     | True          | Whether or not the token should only be    |
+|                |                           |               | sent through a secure HTTPS transport      |
++----------------+---------------------------+---------------+--------------------------------------------+
+| reissue_time   | jwt.cookie_reissue_time   |  None         | Number of seconds (or a datetime.timedelta |
+|                |                           |               | instance) before a cookie (and the token   |
+|                |                           |               | within it) is reissued                     |
++----------------+---------------------------+---------------+--------------------------------------------+
 
 Pyramid JWT example use cases
 =============================
@@ -330,6 +385,41 @@ security backend, we need to also add the following to __init__.py:
 This code will map any properties of the "roles" attribute of the JWT, run them
 through the ACL and then tie them into pyramids security framework.
 
+.. _cookie_examples: Creating a JWT within a cookie
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Since cookie-based authentication is already standardized within Pyramid by the
+``remember()`` and ``forget()`` calls, you should simply use them:
+
+.. code-block:: python
+
+   from pyramid.response import Response
+   from pyramid.security import remember
+
+   @view_config('login', request_method='POST', renderer='json')
+   def login_with_cookies(request):
+       '''Create a login view
+       '''
+       login = request.POST['login']
+       password = request.POST['password']
+       user = authenticate(login, password)  # From the previous snippet
+       if user:
+           headers = remember(
+               user['userid'],
+               roles=user['roles'],
+               userName=user['user_name']
+           )
+           return Response(headers=headers, body="OK")  # Or maybe redirect somewhere else
+       return Response(status=403)  # Or redirect back to login
+
+Please note that since the JWT cookies will be stored inside the cookies,
+there's no need for your app to explicitly include it on the response body.
+The browser (or whatever consuming this response) is responsible to keep that
+cookie for as long as it's valid, and re-send it on the following requests.
+
+Also note that there's no need to decode the cookie manually. The Policy
+handles that through the existing ``request.jwt_claims``.
+
 How is this secure?
 -------------------
 
@@ -340,6 +430,18 @@ tokens as part of the decode process, if it notices that the signature of the
 token is not as expected, it means either the application has been setup
 correctly with the wrong private key, OR an attacker has tried to manipulate
 the token.
+
+The major security concern when working with JWT tokens is where to store the
+token itself: While pyramid_jwt is able to detect tampered tokens, nothing can
+be done if the actual valid token leaks. Any user with a valid token will be
+correctly authenticated within your app. Storing the token securely is outside
+the scope of this library.
+
+When using JWT within a cookie, the browser (or tool consuming the cookie) is
+responsible for storing it, but pyramid_jwt does set the ``http_only`` flag on
+all cookies, so javascript running on the page cannot access these cookies,
+which helps mitigate XSS attacks. It's still mentioning that the tokens are
+still visible through the browser's debugging/inspection tools.
 
 Securing views with JWT's
 -------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ install_requires =
 [options.extras_require]
 testing =
     WebTest
+    pytest
+    pytest-freezegun
 
 [tool:pytest]
 testpaths = tests

--- a/src/pyramid_jwt/__init__.py
+++ b/src/pyramid_jwt/__init__.py
@@ -1,4 +1,8 @@
-from .policy import JWTAuthenticationPolicy, JWTTokenAuthenticationPolicy, json_encoder_factory
+from .policy import (
+    JWTAuthenticationPolicy,
+    JWTTokenAuthenticationPolicy,
+    json_encoder_factory,
+)
 
 
 def includeme(config):
@@ -7,9 +11,10 @@ def includeme(config):
         "set_jwt_authentication_policy", set_jwt_authentication_policy, action_wrap=True
     )
     config.add_directive(
-        'set_jwt_cookie_authentication_policy',
+        "set_jwt_cookie_authentication_policy",
         set_jwt_cookie_authentication_policy,
-        action_wrap=True)
+        action_wrap=True,
+    )
 
 
 def create_jwt_authentication_policy(
@@ -51,12 +56,11 @@ def create_jwt_authentication_policy(
         auth_type=auth_type,
         callback=callback,
         json_encoder=json_encoder,
-        audience=audience
+        audience=audience,
     )
 
 
-def _request_create_token(request, principal, expiration=None,
-                          audience=None, **claims):
+def _request_create_token(request, principal, expiration=None, audience=None, **claims):
 
     return request.authentication_policy.create_token(
         principal, expiration, audience, **claims
@@ -69,26 +73,49 @@ def _request_claims(request):
 
 def _configure(config, auth_policy):
     config.set_authentication_policy(auth_policy)
-    config.add_request_method(lambda request: auth_policy,
-                              'authentication_policy', reify=True)
-    config.add_request_method(_request_claims, 'jwt_claims', reify=True)
-    config.add_request_method(_request_create_token, 'create_jwt_token')
+    config.add_request_method(
+        lambda request: auth_policy, "authentication_policy", reify=True
+    )
+    config.add_request_method(_request_claims, "jwt_claims", reify=True)
+    config.add_request_method(_request_create_token, "create_jwt_token")
 
 
 def set_jwt_cookie_authentication_policy(
-        config, private_key=None, public_key=None,
-        algorithm=None, expiration=None, leeway=None,
-        http_header=None, auth_type=None, callback=None, json_encoder=None,
-        audience=None, cookie_name=None, https_only=False, reissue_time=None):
+    config,
+    private_key=None,
+    public_key=None,
+    algorithm=None,
+    expiration=None,
+    leeway=None,
+    http_header=None,
+    auth_type=None,
+    callback=None,
+    json_encoder=None,
+    audience=None,
+    cookie_name=None,
+    https_only=False,
+    reissue_time=None,
+):
 
     auth_policy = create_jwt_authentication_policy(
-        config, private_key, public_key, algorithm, expiration, leeway,
-        http_header, auth_type, callback, json_encoder, audience
+        config,
+        private_key,
+        public_key,
+        algorithm,
+        expiration,
+        leeway,
+        http_header,
+        auth_type,
+        callback,
+        json_encoder,
+        audience,
     )
 
     auth_policy = JWTTokenAuthenticationPolicy.make_from(
-        auth_policy, cookie_name=cookie_name,
-        https_only=https_only, reissue_time=reissue_time
+        auth_policy,
+        cookie_name=cookie_name,
+        https_only=https_only,
+        reissue_time=reissue_time,
     )
 
     _configure(config, auth_policy)
@@ -105,7 +132,7 @@ def set_jwt_authentication_policy(
     auth_type=None,
     callback=None,
     json_encoder=None,
-    audience=None
+    audience=None,
 ):
     policy = create_jwt_authentication_policy(
         config,
@@ -118,7 +145,7 @@ def set_jwt_authentication_policy(
         auth_type,
         callback,
         json_encoder,
-        audience
+        audience,
     )
 
     _configure(config, policy)

--- a/src/pyramid_jwt/__init__.py
+++ b/src/pyramid_jwt/__init__.py
@@ -1,4 +1,4 @@
-from .policy import JWTAuthenticationPolicy, json_encoder_factory
+from .policy import JWTAuthenticationPolicy, JWTTokenAuthenticationPolicy, json_encoder_factory
 
 
 def includeme(config):
@@ -6,6 +6,11 @@ def includeme(config):
     config.add_directive(
         "set_jwt_authentication_policy", set_jwt_authentication_policy, action_wrap=True
     )
+    config.add_directive(
+        'set_jwt_cookie_authentication_policy',
+        set_jwt_cookie_authentication_policy,
+        action_wrap=True)
+
 
 
 def create_jwt_authentication_policy(
@@ -47,8 +52,47 @@ def create_jwt_authentication_policy(
         auth_type=auth_type,
         callback=callback,
         json_encoder=json_encoder,
-        audience=audience,
+        audience=audience
     )
+
+
+def _request_create_token(request, principal, expiration=None,
+                          audience=None, **claims):
+
+    return request.authentication_policy.create_token(
+        principal, expiration, audience, **claims
+    )
+
+
+def _request_claims(request):
+    return request.authentication_policy.get_claims(request)
+
+
+def _configure(config, auth_policy):
+    config.set_authentication_policy(auth_policy)
+    config.add_request_method(lambda request: auth_policy,
+                              'authentication_policy', reify=True)
+    config.add_request_method(_request_claims, 'jwt_claims', reify=True)
+    config.add_request_method(_request_create_token, 'create_jwt_token')
+
+
+def set_jwt_cookie_authentication_policy(
+        config, private_key=None, public_key=None,
+        algorithm=None, expiration=None, leeway=None,
+        http_header=None, auth_type=None, callback=None, json_encoder=None,
+        audience=None, cookie_name=None, https_only=False, reissue_time=None):
+
+    auth_policy = create_jwt_authentication_policy(
+        config, private_key, public_key, algorithm, expiration, leeway,
+        http_header, auth_type, callback, json_encoder, audience
+    )
+
+    auth_policy = JWTTokenAuthenticationPolicy.make_from(
+        auth_policy, cookie_name=cookie_name,
+        https_only=https_only, reissue_time=reissue_time
+    )
+
+    _configure(config, auth_policy)
 
 
 def set_jwt_authentication_policy(
@@ -62,7 +106,7 @@ def set_jwt_authentication_policy(
     auth_type=None,
     callback=None,
     json_encoder=None,
-    audience=None,
+    audience=None
 ):
     policy = create_jwt_authentication_policy(
         config,
@@ -75,17 +119,7 @@ def set_jwt_authentication_policy(
         auth_type,
         callback,
         json_encoder,
-        audience,
+        audience
     )
 
-    def request_create_token(
-        request, principal, expiration=None, audience=None, **claims
-    ):
-        return policy.create_token(principal, expiration, audience, **claims)
-
-    def request_claims(request):
-        return policy.get_claims(request)
-
-    config.set_authentication_policy(policy)
-    config.add_request_method(request_create_token, "create_jwt_token")
-    config.add_request_method(request_claims, "jwt_claims", reify=True)
+    _configure(config, policy)

--- a/src/pyramid_jwt/__init__.py
+++ b/src/pyramid_jwt/__init__.py
@@ -12,7 +12,6 @@ def includeme(config):
         action_wrap=True)
 
 
-
 def create_jwt_authentication_policy(
     config,
     private_key=None,

--- a/src/pyramid_jwt/__init__.py
+++ b/src/pyramid_jwt/__init__.py
@@ -1,6 +1,6 @@
 from .policy import (
     JWTAuthenticationPolicy,
-    JWTTokenAuthenticationPolicy,
+    JWTCookieAuthenticationPolicy,
     json_encoder_factory,
 )
 
@@ -111,7 +111,7 @@ def set_jwt_cookie_authentication_policy(
         audience,
     )
 
-    auth_policy = JWTTokenAuthenticationPolicy.make_from(
+    auth_policy = JWTCookieAuthenticationPolicy.make_from(
         auth_policy,
         cookie_name=cookie_name,
         https_only=https_only,

--- a/src/pyramid_jwt/__init__.py
+++ b/src/pyramid_jwt/__init__.py
@@ -93,9 +93,14 @@ def set_jwt_cookie_authentication_policy(
     json_encoder=None,
     audience=None,
     cookie_name=None,
-    https_only=False,
+    https_only=True,
     reissue_time=None,
 ):
+    settings = config.get_settings()
+    cookie_name = cookie_name or settings.get("jwt.cookie_name")
+    reissue_time = reissue_time or settings.get("jwt.cookie_reissue_time")
+    if https_only is None:
+        https_only = settings.get("jwt.https_only_cookie", True)
 
     auth_policy = create_jwt_authentication_policy(
         config,

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -159,7 +159,7 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
                  leeway=0, expiration=None, default_claims=None,
                  http_header='Authorization', auth_type='JWT',
                  callback=None, json_encoder=None, audience=None,
-                 cookie_name='Authorization', https_only=False,
+                 cookie_name='Authorization', https_only=True,
                  reissue_time=None):
         super(JWTTokenAuthenticationPolicy, self).__init__(
             private_key, public_key, algorithm,

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -154,7 +154,7 @@ class ReissueError(Exception):
 
 
 @implementer(IAuthenticationPolicy)
-class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
+class JWTCookieAuthenticationPolicy(JWTAuthenticationPolicy):
     def __init__(
         self,
         private_key,
@@ -172,7 +172,7 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
         https_only=True,
         reissue_time=None,
     ):
-        super(JWTTokenAuthenticationPolicy, self).__init__(
+        super(JWTCookieAuthenticationPolicy, self).__init__(
             private_key,
             public_key,
             algorithm,
@@ -208,7 +208,7 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
             pol_type = policy.__class__.__name__
             raise TypeError("Invalid policy type %s" % pol_type)
 
-        return JWTTokenAuthenticationPolicy(
+        return JWTCookieAuthenticationPolicy(
             private_key=policy.private_key,
             public_key=policy.public_key,
             algorithm=policy.algorithm,

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -266,9 +266,7 @@ class JWTCookieAuthenticationPolicy(JWTAuthenticationPolicy):
 
     def _handle_reissue(self, request, claims):
         if not request or not claims:
-            raise ValueError(
-                "Cannot handle JWT reissue: insufficient arguments"
-            )
+            raise ValueError("Cannot handle JWT reissue: insufficient arguments")
 
         if "iat" not in claims:
             raise ReissueError("Token claim's is missing IAT")

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -206,7 +206,7 @@ class JWTCookieAuthenticationPolicy(JWTAuthenticationPolicy):
     def make_from(policy, **kwargs):
         if not isinstance(policy, JWTAuthenticationPolicy):
             pol_type = policy.__class__.__name__
-            raise TypeError("Invalid policy type %s" % pol_type)
+            raise ValueError("Invalid policy type %s" % pol_type)
 
         return JWTCookieAuthenticationPolicy(
             private_key=policy.private_key,
@@ -266,7 +266,9 @@ class JWTCookieAuthenticationPolicy(JWTAuthenticationPolicy):
 
     def _handle_reissue(self, request, claims):
         if not request or not claims:
-            raise AttributeError("Cannot handle JWT reissue: insufficient arguments")
+            raise ValueError(
+                "Cannot handle JWT reissue: insufficient arguments"
+            )
 
         if "iat" not in claims:
             raise ReissueError("Token claim's is missing IAT")

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -242,7 +242,6 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
         return claims
 
     def _handle_reissue(self, request, claims):
-        import pdb; pdb.set_trace()
         if not request or not claims:
             raise AttributeError(
                 "Cannot handle JWT reissue: insufficient arguments")
@@ -261,7 +260,8 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
             return
 
         extra_claims = dict(
-            filter(lambda k, v: k not in self.jwt_std_claims, claims.items())
+            filter(lambda item: item[0] not in self.jwt_std_claims,
+                   claims.items())
         )
         headers = self.remember(request, principal, **extra_claims)
 
@@ -269,5 +269,5 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
             if not hasattr(request, '_jwt_cookie_reissue_revoked'):
                 for k, v in headers:
                     response.headerlist.append((k, v))
-            request.add_response_callback(reissiue_jwt_cookie)
-            request._jwt_cookie_reissued = True
+        request.add_response_callback(reissiue_jwt_cookie)
+        request._jwt_cookie_reissued = True

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -265,9 +265,9 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
         )
         headers = self.remember(request, principal, **extra_claims)
 
-        def reissiue_jwt_cookie(request, response):
+        def reissue_jwt_cookie(request, response):
             if not hasattr(request, '_jwt_cookie_reissue_revoked'):
                 for k, v in headers:
                     response.headerlist.append((k, v))
-        request.add_response_callback(reissiue_jwt_cookie)
+        request.add_response_callback(reissue_jwt_cookie)
         request._jwt_cookie_reissued = True

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -187,7 +187,7 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
     def make_from(policy, **kwargs):
         if not isinstance(policy, JWTAuthenticationPolicy):
             pol_type = policy.__class__.__name__
-            raise AttributeError('Invalid policy type %s' % pol_type)
+            raise TypeError('Invalid policy type %s' % pol_type)
 
         return JWTTokenAuthenticationPolicy(
             private_key=policy.private_key,

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -225,7 +225,7 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
 
     def _get_cookies(self, request, value, max_age=None, domains=None):
         profile = self.cookie_profile(request)
-        if not domains:
+        if domains is None:
             domains = [request.domain]
 
         kw = {"domains": domains}
@@ -246,6 +246,7 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
         return self._get_cookies(request, token, self.max_age, domains=domains)
 
     def forget(self, request):
+        request._jwt_cookie_reissue_revoked = True
         return self._get_cookies(request, None)
 
     def get_claims(self, request):

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -168,7 +168,7 @@ class JWTCookieAuthenticationPolicy(JWTAuthenticationPolicy):
         callback=None,
         json_encoder=None,
         audience=None,
-        cookie_name="Authorization",
+        cookie_name=None,
         https_only=True,
         reissue_time=None,
     ):
@@ -187,7 +187,7 @@ class JWTCookieAuthenticationPolicy(JWTAuthenticationPolicy):
         )
 
         self.https_only = https_only
-        self.cookie_name = cookie_name
+        self.cookie_name = cookie_name or "Authorization"
         self.max_age = self.expiration and self.expiration.total_seconds()
 
         if reissue_time and isinstance(reissue_time, datetime.timedelta):

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -183,6 +183,27 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
             path=None
         )
 
+    @staticmethod
+    def make_from(policy, **kwargs):
+        if not isinstance(policy, JWTAuthenticationPolicy):
+            pol_type = policy.__class__.__name__
+            raise AttributeError('Invalid policy type %s' % pol_type)
+
+        return JWTTokenAuthenticationPolicy(
+            private_key=policy.private_key,
+            public_key=policy.public_key,
+            algorithm=policy.algorithm,
+            leeway=policy.leeway,
+            expiration=policy.expiration,
+            default_claims=policy.default_claims,
+            http_header=policy.http_header,
+            auth_type=policy.auth_type,
+            callback=policy.callback,
+            json_encoder=policy.json_encoder,
+            audience=policy.audience,
+            **kwargs
+        )
+
     def _get_cookies(self, request, value, max_age=None):
         profile = self.cookie_profile(request)
 

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -204,10 +204,12 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
             **kwargs
         )
 
-    def _get_cookies(self, request, value, max_age=None):
+    def _get_cookies(self, request, value, max_age=None, domains=None):
         profile = self.cookie_profile(request)
+        if not domains:
+            domains = [request.domain]
 
-        kw = {'domains': [request.domain]}
+        kw = {'domains': domains}
         if max_age is not None:
             kw['max_age'] = max_age
 
@@ -221,7 +223,9 @@ class JWTTokenAuthenticationPolicy(JWTAuthenticationPolicy):
         if hasattr(request, '_jwt_cookie_reissued'):
             request._jwt_cookie_reissue_revoked = True
 
-        return self._get_cookies(request, token, self.max_age)
+        domains = kw.get('domains')
+
+        return self._get_cookies(request, token, self.max_age, domains=domains)
 
     def forget(self, request):
         return self._get_cookies(request, None)

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,0 +1,63 @@
+import uuid
+
+from pyramid.interfaces import IAuthenticationPolicy
+from webob import Request
+from zope.interface.verify import verifyObject
+
+from pyramid_jwt.policy import JWTTokenAuthenticationPolicy
+
+
+def test_interface():
+    verifyObject(IAuthenticationPolicy, JWTTokenAuthenticationPolicy('secret'))
+
+
+def test_cookie():
+    policy = JWTTokenAuthenticationPolicy('secret')
+    request = Request.blank('/')
+    cookie = policy.remember(request, str(uuid.uuid4())).pop()
+
+    assert len(cookie) == 2
+
+    header, cookie = cookie
+    assert header == 'Set-Cookie'
+    assert len(cookie) > 0
+
+
+def test_cookie_name():
+    policy = JWTTokenAuthenticationPolicy('secret', cookie_name='auth')
+    request = Request.blank('/')
+    _, cookie = policy.remember(request, str(uuid.uuid4())).pop()
+
+    name, value = cookie.split('=', 1)
+    assert name == 'auth'
+
+
+def test_secure_cookie():
+    policy = JWTTokenAuthenticationPolicy('secret', https_only=True)
+    request = Request.blank('/')
+    _, cookie = policy.remember(request, str(uuid.uuid4())).pop()
+
+    assert '; secure;' in cookie
+    assert '; HttpOnly' in cookie
+
+
+def test_insecure_cookie():
+    policy = JWTTokenAuthenticationPolicy('secret', https_only=False)
+    request = Request.blank('/')
+    _, cookie = policy.remember(request, str(uuid.uuid4())).pop()
+
+    assert '; secure;' not in cookie
+    assert '; HttpOnly' in cookie
+
+
+def test_cookie_decode():
+    policy = JWTTokenAuthenticationPolicy('secret', https_only=False)
+    request = Request.blank('/')
+
+    principal = str(uuid.uuid4())
+    header, cookie = policy.remember(request, principal).pop()
+    name, value = cookie.split('=', 1)
+    request.cookies = {name: value.split(';', 1)[0]}
+
+    claims = policy.get_claims(request)
+    assert claims['sub'] == principal

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -15,7 +15,7 @@ def principal():
 
 
 @pytest.fixture(scope='module')
-def request():
+def dummy_request():
     return Request.blank('/')
 
 
@@ -23,9 +23,9 @@ def test_interface():
     verifyObject(IAuthenticationPolicy, JWTTokenAuthenticationPolicy('secret'))
 
 
-def test_cookie(request, principal):
+def test_cookie(dummy_request, principal):
     policy = JWTTokenAuthenticationPolicy('secret')
-    cookie = policy.remember(request, principal).pop()
+    cookie = policy.remember(dummy_request, principal).pop()
 
     assert len(cookie) == 2
 
@@ -34,9 +34,9 @@ def test_cookie(request, principal):
     assert len(cookie) > 0
 
 
-def test_cookie_name(request, principal):
+def test_cookie_name(dummy_request, principal):
     policy = JWTTokenAuthenticationPolicy('secret', cookie_name='auth')
-    _, cookie = policy.remember(request, principal).pop()
+    _, cookie = policy.remember(dummy_request, principal).pop()
 
     name, value = cookie.split('=', 1)
     assert name == 'auth'
@@ -44,38 +44,38 @@ def test_cookie_name(request, principal):
 
 def test_secure_cookie():
     policy = JWTTokenAuthenticationPolicy('secret', https_only=True)
-    request = Request.blank('/')
-    _, cookie = policy.remember(request, str(uuid.uuid4())).pop()
+    dummy_request = Request.blank('/')
+    _, cookie = policy.remember(dummy_request, str(uuid.uuid4())).pop()
 
     assert '; secure;' in cookie
     assert '; HttpOnly' in cookie
 
 
-def test_insecure_cookie(request, principal):
+def test_insecure_cookie(dummy_request, principal):
     policy = JWTTokenAuthenticationPolicy('secret', https_only=False)
-    _, cookie = policy.remember(request, principal).pop()
+    _, cookie = policy.remember(dummy_request, principal).pop()
 
     assert '; secure;' not in cookie
     assert '; HttpOnly' in cookie
 
 
-def test_cookie_decode(request, principal):
+def test_cookie_decode(dummy_request, principal):
     policy = JWTTokenAuthenticationPolicy('secret', https_only=False)
 
-    header, cookie = policy.remember(request, principal).pop()
+    header, cookie = policy.remember(dummy_request, principal).pop()
     name, value = cookie.split('=', 1)
 
     value, _ = value.split(';', 1)
-    request.cookies = {name: value}
+    dummy_request.cookies = {name: value}
 
-    claims = policy.get_claims(request)
+    claims = policy.get_claims(dummy_request)
     assert claims['sub'] == principal
 
 
-def test_cookie_max_age(request, principal):
+def test_cookie_max_age(dummy_request, principal):
     policy = JWTTokenAuthenticationPolicy('secret', cookie_name='auth',
                                           expiration=100)
-    _, cookie = policy.remember(request, principal).pop()
+    _, cookie = policy.remember(dummy_request, principal).pop()
     _, value = cookie.split('=', 1)
 
     _, meta = value.split(';', 1)
@@ -84,16 +84,16 @@ def test_cookie_max_age(request, principal):
 
 
 @pytest.mark.freeze_time
-def test_expired_token(request, principal, freezer):
+def test_expired_token(dummy_request, principal, freezer):
     policy = JWTTokenAuthenticationPolicy('secret', cookie_name='auth',
                                           expiration=1)
-    _, cookie = policy.remember(request, principal).pop()
+    _, cookie = policy.remember(dummy_request, principal).pop()
     name, value = cookie.split('=', 1)
 
     freezer.tick(delta=2)
 
     value, _ = value.split(';', 1)
-    request.cookies = {name: value}
-    claims = policy.get_claims(request)
+    dummy_request.cookies = {name: value}
+    claims = policy.get_claims(dummy_request)
 
     assert claims == {}

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -6,7 +6,7 @@ from pyramid.interfaces import IAuthenticationPolicy
 from webob import Request
 from zope.interface.verify import verifyObject
 
-from pyramid_jwt.policy import JWTTokenAuthenticationPolicy
+from pyramid_jwt.policy import JWTCookieAuthenticationPolicy
 
 
 @pytest.fixture(scope="module")
@@ -20,11 +20,11 @@ def dummy_request():
 
 
 def test_interface():
-    verifyObject(IAuthenticationPolicy, JWTTokenAuthenticationPolicy("secret"))
+    verifyObject(IAuthenticationPolicy, JWTCookieAuthenticationPolicy("secret"))
 
 
 def test_cookie(dummy_request, principal):
-    policy = JWTTokenAuthenticationPolicy("secret")
+    policy = JWTCookieAuthenticationPolicy("secret")
     cookie = policy.remember(dummy_request, principal).pop()
 
     assert len(cookie) == 2
@@ -35,7 +35,7 @@ def test_cookie(dummy_request, principal):
 
 
 def test_cookie_name(dummy_request, principal):
-    policy = JWTTokenAuthenticationPolicy("secret", cookie_name="auth")
+    policy = JWTCookieAuthenticationPolicy("secret", cookie_name="auth")
     _, cookie = policy.remember(dummy_request, principal).pop()
 
     name, value = cookie.split("=", 1)
@@ -43,7 +43,7 @@ def test_cookie_name(dummy_request, principal):
 
 
 def test_secure_cookie():
-    policy = JWTTokenAuthenticationPolicy("secret", https_only=True)
+    policy = JWTCookieAuthenticationPolicy("secret", https_only=True)
     dummy_request = Request.blank("/")
     _, cookie = policy.remember(dummy_request, str(uuid.uuid4())).pop()
 
@@ -52,7 +52,7 @@ def test_secure_cookie():
 
 
 def test_insecure_cookie(dummy_request, principal):
-    policy = JWTTokenAuthenticationPolicy("secret", https_only=False)
+    policy = JWTCookieAuthenticationPolicy("secret", https_only=False)
     _, cookie = policy.remember(dummy_request, principal).pop()
 
     assert "; secure;" not in cookie
@@ -60,7 +60,7 @@ def test_insecure_cookie(dummy_request, principal):
 
 
 def test_cookie_decode(dummy_request, principal):
-    policy = JWTTokenAuthenticationPolicy("secret", https_only=False)
+    policy = JWTCookieAuthenticationPolicy("secret", https_only=False)
 
     header, cookie = policy.remember(dummy_request, principal).pop()
     name, value = cookie.split("=", 1)
@@ -73,7 +73,7 @@ def test_cookie_decode(dummy_request, principal):
 
 
 def test_cookie_max_age(dummy_request, principal):
-    policy = JWTTokenAuthenticationPolicy("secret", cookie_name="auth", expiration=100)
+    policy = JWTCookieAuthenticationPolicy("secret", cookie_name="auth", expiration=100)
     _, cookie = policy.remember(dummy_request, principal).pop()
     _, value = cookie.split("=", 1)
 
@@ -84,7 +84,7 @@ def test_cookie_max_age(dummy_request, principal):
 
 @pytest.mark.freeze_time
 def test_expired_token(dummy_request, principal, freezer):
-    policy = JWTTokenAuthenticationPolicy("secret", cookie_name="auth", expiration=1)
+    policy = JWTCookieAuthenticationPolicy("secret", cookie_name="auth", expiration=1)
     _, cookie = policy.remember(dummy_request, principal).pop()
     name, value = cookie.split("=", 1)
 

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pytest
+
 from pyramid.interfaces import IAuthenticationPolicy
 from webob import Request
 from zope.interface.verify import verifyObject
@@ -7,14 +9,23 @@ from zope.interface.verify import verifyObject
 from pyramid_jwt.policy import JWTTokenAuthenticationPolicy
 
 
+@pytest.fixture(scope='module')
+def principal():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture(scope='module')
+def request():
+    return Request.blank('/')
+
+
 def test_interface():
     verifyObject(IAuthenticationPolicy, JWTTokenAuthenticationPolicy('secret'))
 
 
-def test_cookie():
+def test_cookie(request, principal):
     policy = JWTTokenAuthenticationPolicy('secret')
-    request = Request.blank('/')
-    cookie = policy.remember(request, str(uuid.uuid4())).pop()
+    cookie = policy.remember(request, principal).pop()
 
     assert len(cookie) == 2
 
@@ -23,10 +34,9 @@ def test_cookie():
     assert len(cookie) > 0
 
 
-def test_cookie_name():
+def test_cookie_name(request, principal):
     policy = JWTTokenAuthenticationPolicy('secret', cookie_name='auth')
-    request = Request.blank('/')
-    _, cookie = policy.remember(request, str(uuid.uuid4())).pop()
+    _, cookie = policy.remember(request, principal).pop()
 
     name, value = cookie.split('=', 1)
     assert name == 'auth'
@@ -41,20 +51,17 @@ def test_secure_cookie():
     assert '; HttpOnly' in cookie
 
 
-def test_insecure_cookie():
+def test_insecure_cookie(request, principal):
     policy = JWTTokenAuthenticationPolicy('secret', https_only=False)
-    request = Request.blank('/')
-    _, cookie = policy.remember(request, str(uuid.uuid4())).pop()
+    _, cookie = policy.remember(request, principal).pop()
 
     assert '; secure;' not in cookie
     assert '; HttpOnly' in cookie
 
 
-def test_cookie_decode():
+def test_cookie_decode(request, principal):
     policy = JWTTokenAuthenticationPolicy('secret', https_only=False)
-    request = Request.blank('/')
 
-    principal = str(uuid.uuid4())
     header, cookie = policy.remember(request, principal).pop()
     name, value = cookie.split('=', 1)
     request.cookies = {name: value.split(';', 1)[0]}

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -9,90 +9,88 @@ from zope.interface.verify import verifyObject
 from pyramid_jwt.policy import JWTTokenAuthenticationPolicy
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def principal():
     return str(uuid.uuid4())
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def dummy_request():
-    return Request.blank('/')
+    return Request.blank("/")
 
 
 def test_interface():
-    verifyObject(IAuthenticationPolicy, JWTTokenAuthenticationPolicy('secret'))
+    verifyObject(IAuthenticationPolicy, JWTTokenAuthenticationPolicy("secret"))
 
 
 def test_cookie(dummy_request, principal):
-    policy = JWTTokenAuthenticationPolicy('secret')
+    policy = JWTTokenAuthenticationPolicy("secret")
     cookie = policy.remember(dummy_request, principal).pop()
 
     assert len(cookie) == 2
 
     header, cookie = cookie
-    assert header == 'Set-Cookie'
+    assert header == "Set-Cookie"
     assert len(cookie) > 0
 
 
 def test_cookie_name(dummy_request, principal):
-    policy = JWTTokenAuthenticationPolicy('secret', cookie_name='auth')
+    policy = JWTTokenAuthenticationPolicy("secret", cookie_name="auth")
     _, cookie = policy.remember(dummy_request, principal).pop()
 
-    name, value = cookie.split('=', 1)
-    assert name == 'auth'
+    name, value = cookie.split("=", 1)
+    assert name == "auth"
 
 
 def test_secure_cookie():
-    policy = JWTTokenAuthenticationPolicy('secret', https_only=True)
-    dummy_request = Request.blank('/')
+    policy = JWTTokenAuthenticationPolicy("secret", https_only=True)
+    dummy_request = Request.blank("/")
     _, cookie = policy.remember(dummy_request, str(uuid.uuid4())).pop()
 
-    assert '; secure;' in cookie
-    assert '; HttpOnly' in cookie
+    assert "; secure;" in cookie
+    assert "; HttpOnly" in cookie
 
 
 def test_insecure_cookie(dummy_request, principal):
-    policy = JWTTokenAuthenticationPolicy('secret', https_only=False)
+    policy = JWTTokenAuthenticationPolicy("secret", https_only=False)
     _, cookie = policy.remember(dummy_request, principal).pop()
 
-    assert '; secure;' not in cookie
-    assert '; HttpOnly' in cookie
+    assert "; secure;" not in cookie
+    assert "; HttpOnly" in cookie
 
 
 def test_cookie_decode(dummy_request, principal):
-    policy = JWTTokenAuthenticationPolicy('secret', https_only=False)
+    policy = JWTTokenAuthenticationPolicy("secret", https_only=False)
 
     header, cookie = policy.remember(dummy_request, principal).pop()
-    name, value = cookie.split('=', 1)
+    name, value = cookie.split("=", 1)
 
-    value, _ = value.split(';', 1)
+    value, _ = value.split(";", 1)
     dummy_request.cookies = {name: value}
 
     claims = policy.get_claims(dummy_request)
-    assert claims['sub'] == principal
+    assert claims["sub"] == principal
 
 
 def test_cookie_max_age(dummy_request, principal):
-    policy = JWTTokenAuthenticationPolicy('secret', cookie_name='auth',
-                                          expiration=100)
+    policy = JWTTokenAuthenticationPolicy("secret", cookie_name="auth", expiration=100)
     _, cookie = policy.remember(dummy_request, principal).pop()
-    _, value = cookie.split('=', 1)
+    _, value = cookie.split("=", 1)
 
-    _, meta = value.split(';', 1)
-    assert 'Max-Age=100' in meta
+    _, meta = value.split(";", 1)
+    assert "Max-Age=100" in meta
     assert "expires" in meta
 
 
 @pytest.mark.freeze_time
 def test_expired_token(dummy_request, principal, freezer):
-    policy = JWTTokenAuthenticationPolicy('secret', cookie_name='auth',
-                                          expiration=1)
+    policy = JWTTokenAuthenticationPolicy("secret", cookie_name="auth", expiration=1)
     _, cookie = policy.remember(dummy_request, principal).pop()
-    name, value = cookie.split('=', 1)
+    name, value = cookie.split("=", 1)
 
     freezer.tick(delta=2)
 
-    value, _ = value.split(';', 1)
+    value, _ = value.split(";", 1)
     dummy_request.cookies = {name: value}
     claims = policy.get_claims(dummy_request)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -101,11 +101,12 @@ def cookie_config(base_config):
         logout_cookie_view, route_name="logout", renderer="string", permission="read"
     )
 
-
     base_config.add_route("suspicious", "/suspicious")
     base_config.add_view(
-        suspicious_behaviour_view, route_name="suspicious",
-        renderer="string", permission="read"
+        suspicious_behaviour_view,
+        route_name="suspicious",
+        renderer="string",
+        permission="read",
     )
 
     # Enable JWT authentication on Cookies.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,13 +2,18 @@ import pytest
 from pyramid.config import Configurator
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.renderers import JSON
-from pyramid.security import Authenticated
-from pyramid.security import Allow
+from pyramid.response import Response
+from pyramid.security import Allow, Authenticated, remember
 from webtest import TestApp
 
 
 def login_view(request):
     return {"token": request.create_jwt_token(1)}
+
+
+def login_cookie_view(request):
+    headers = remember(request, 1)
+    return Response(status=200, headers=headers, body="OK")
 
 
 def secure_view(request):
@@ -39,20 +44,19 @@ class Serializable(object):
 
 def extra_claims(request):
     return {
-        "token": request.create_jwt_token(principal=1, extra_claim=NonSerializable())
+        "token": request.create_jwt_token(
+            principal=1, extra_claim=NonSerializable()
+        )
     }
 
 
-@pytest.fixture(scope="module")
-def app_config() -> Configurator:
+@pytest.fixture(scope="function")
+def base_config() -> Configurator:
     config = Configurator()
     config.set_authorization_policy(ACLAuthorizationPolicy())
-    # Enable JWT authentication.
+
     config.include("pyramid_jwt")
     config.set_root_factory(Root)
-    config.set_jwt_authentication_policy("secret", http_header="X-Token")
-    config.add_route("login", "/login")
-    config.add_view(login_view, route_name="login", renderer="json")
     config.add_route("secure", "/secure")
     config.add_view(
         secure_view, route_name="secure", renderer="string", permission="read"
@@ -66,9 +70,45 @@ def app_config() -> Configurator:
     return config
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
+def app_config(base_config) -> Configurator:
+    base_config.add_route("login", "/login")
+    base_config.add_view(login_view, route_name="login", renderer="json")
+
+    # Enable JWT authentication.
+    base_config.set_jwt_authentication_policy(
+        "secret",
+        http_header="X-Token"
+    )
+    return base_config
+
+
+@pytest.fixture(scope='function')
+def cookie_config(base_config):
+    base_config.add_route("login", "/login")
+    base_config.add_view(
+        login_cookie_view, route_name="login", renderer="json"
+    )
+
+    # Enable JWT authentication on Cookies.
+    base_config.set_jwt_cookie_authentication_policy(
+        'secret',
+        cookie_name='Token',
+        expiration=5,
+        reissue_time=1
+    )
+    return base_config
+
+
+@pytest.fixture(scope="function")
 def app(app_config):
     app = app_config.make_wsgi_app()
+    return TestApp(app)
+
+
+@pytest.fixture(scope="function")
+def cookie_app(cookie_config):
+    app = cookie_config.make_wsgi_app()
     return TestApp(app)
 
 
@@ -129,3 +169,29 @@ def test_pyramid_custom_json_encoder(app_config: Configurator):
 
     response = app.get("/dump_claims", headers={"X-Token": token})
     assert response.json_body["extra_claim"] == "other_serializer"
+
+
+def test_cookie_secured(cookie_app):
+    response = cookie_app.get('/secure', expect_errors=True)
+    assert response.status_int == 403
+
+
+def test_cookie_login(cookie_app):
+    response = cookie_app.get('/login')
+    assert 'Token' in cookie_app.cookies
+    assert response.body == b"OK"
+
+    response = cookie_app.get('/secure')
+    assert response.body == b'OK'
+
+
+@pytest.mark.freeze_time
+def test_cookie_reiisue(cookie_app, freezer):
+    cookie_app.get('/login')
+    token = cookie_app.cookies.get('Token')
+
+    freezer.tick(delta=5)
+
+    cookie_app.get('/secure')
+    other_token = cookie_app.cookies.get('Token')
+    assert token != other_token

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -112,8 +112,11 @@ def cookie_config(base_config):
     # Enable JWT authentication on Cookies.
     reissue_time = timedelta(seconds=1)
     base_config.set_jwt_cookie_authentication_policy(
-        "secret", cookie_name="Token", expiration=5, reissue_time=reissue_time,
-        https_only=False
+        "secret",
+        cookie_name="Token",
+        expiration=5,
+        reissue_time=reissue_time,
+        https_only=False,
     )
     return base_config
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -190,7 +190,7 @@ def test_cookie_reiisue(cookie_app, freezer):
     cookie_app.get('/login')
     token = cookie_app.cookies.get('Token')
 
-    freezer.tick(delta=5)
+    freezer.tick(delta=4)
 
     cookie_app.get('/secure')
     other_token = cookie_app.cookies.get('Token')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,9 +44,7 @@ class Serializable(object):
 
 def extra_claims(request):
     return {
-        "token": request.create_jwt_token(
-            principal=1, extra_claim=NonSerializable()
-        )
+        "token": request.create_jwt_token(principal=1, extra_claim=NonSerializable())
     }
 
 
@@ -76,26 +74,18 @@ def app_config(base_config) -> Configurator:
     base_config.add_view(login_view, route_name="login", renderer="json")
 
     # Enable JWT authentication.
-    base_config.set_jwt_authentication_policy(
-        "secret",
-        http_header="X-Token"
-    )
+    base_config.set_jwt_authentication_policy("secret", http_header="X-Token")
     return base_config
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def cookie_config(base_config):
     base_config.add_route("login", "/login")
-    base_config.add_view(
-        login_cookie_view, route_name="login", renderer="json"
-    )
+    base_config.add_view(login_cookie_view, route_name="login", renderer="json")
 
     # Enable JWT authentication on Cookies.
     base_config.set_jwt_cookie_authentication_policy(
-        'secret',
-        cookie_name='Token',
-        expiration=5,
-        reissue_time=1
+        "secret", cookie_name="Token", expiration=5, reissue_time=1
     )
     return base_config
 
@@ -172,26 +162,26 @@ def test_pyramid_custom_json_encoder(app_config: Configurator):
 
 
 def test_cookie_secured(cookie_app):
-    response = cookie_app.get('/secure', expect_errors=True)
+    response = cookie_app.get("/secure", expect_errors=True)
     assert response.status_int == 403
 
 
 def test_cookie_login(cookie_app):
-    response = cookie_app.get('/login')
-    assert 'Token' in cookie_app.cookies
+    response = cookie_app.get("/login")
+    assert "Token" in cookie_app.cookies
     assert response.body == b"OK"
 
-    response = cookie_app.get('/secure')
-    assert response.body == b'OK'
+    response = cookie_app.get("/secure")
+    assert response.body == b"OK"
 
 
 @pytest.mark.freeze_time
 def test_cookie_reiisue(cookie_app, freezer):
-    cookie_app.get('/login')
-    token = cookie_app.cookies.get('Token')
+    cookie_app.get("/login")
+    token = cookie_app.cookies.get("Token")
 
     freezer.tick(delta=4)
 
-    cookie_app.get('/secure')
-    other_token = cookie_app.cookies.get('Token')
+    cookie_app.get("/secure")
+    other_token = cookie_app.cookies.get("Token")
     assert token != other_token

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -112,7 +112,8 @@ def cookie_config(base_config):
     # Enable JWT authentication on Cookies.
     reissue_time = timedelta(seconds=1)
     base_config.set_jwt_cookie_authentication_policy(
-        "secret", cookie_name="Token", expiration=5, reissue_time=reissue_time
+        "secret", cookie_name="Token", expiration=5, reissue_time=reissue_time,
+        https_only=False
     )
     return base_config
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -10,7 +10,11 @@ from pyramid.testing import testConfig
 from pyramid.testing import DummyRequest
 from pyramid.testing import DummySecurityPolicy
 from pyramid.interfaces import IAuthenticationPolicy
-from pyramid_jwt.policy import JWTAuthenticationPolicy, PyramidJSONEncoderFactory, JWTTokenAuthenticationPolicy
+from pyramid_jwt.policy import (
+    JWTAuthenticationPolicy,
+    PyramidJSONEncoderFactory,
+    JWTTokenAuthenticationPolicy,
+)
 import uuid
 import pytest
 from json.encoder import JSONEncoder
@@ -37,7 +41,7 @@ def test_minimal_roundtrip():
 
 def test_audience_valid():
     policy = JWTAuthenticationPolicy("secret", audience="example.org")
-    token = policy.create_token(15, name=u"Jöhn", admin=True, audience="example.org")
+    token = policy.create_token(15, name="Jöhn", admin=True, audience="example.org")
     request = Request.blank("/")
     request.authorization = ("JWT", token)
     jwt_claims = policy.get_claims(request)
@@ -46,7 +50,7 @@ def test_audience_valid():
 
 def test_audience_invalid():
     policy = JWTAuthenticationPolicy("secret", audience="example.org")
-    token = policy.create_token(15, name=u"Jöhn", admin=True, audience="example.com")
+    token = policy.create_token(15, name="Jöhn", admin=True, audience="example.com")
     request = Request.blank("/")
     request.authorization = ("JWT", token)
     jwt_claims = policy.get_claims(request)
@@ -56,16 +60,16 @@ def test_audience_invalid():
 def test_algorithm_unsupported():
     policy = JWTAuthenticationPolicy("secret", algorithm="SHA1")
     with pytest.raises(NotImplementedError):
-        token = policy.create_token(15, name=u"Jöhn", admin=True)
+        token = policy.create_token(15, name="Jöhn", admin=True)
 
 
 def test_extra_claims():
     policy = JWTAuthenticationPolicy("secret")
-    token = policy.create_token(15, name=u"Jöhn", admin=True)
+    token = policy.create_token(15, name="Jöhn", admin=True)
     request = Request.blank("/")
     request.authorization = ("JWT", token)
     jwt_claims = policy.get_claims(request)
-    assert jwt_claims["name"] == u"Jöhn"
+    assert jwt_claims["name"] == "Jöhn"
     assert jwt_claims["admin"]
 
 
@@ -206,7 +210,7 @@ def test_cookie_policy_remember():
     header, cookie = headers[0]
     assert header.lower() == "set-cookie"
 
-    chunks = cookie.split('; ')
+    chunks = cookie.split("; ")
     assert chunks[0].startswith(f"{policy.cookie_name}=")
 
     assert "HttpOnly" in chunks
@@ -221,12 +225,12 @@ def test_cookie_policy_forget():
     header, cookie = headers[0]
     assert header.lower() == "set-cookie"
 
-    chunks = cookie.split('; ')
-    cookie_values = [c for c in chunks if '=' in c]
+    chunks = cookie.split("; ")
+    cookie_values = [c for c in chunks if "=" in c]
     assert cookie_values[0].startswith(f"{policy.cookie_name}=")
 
     assert "Max-Age=0" in chunks
-    assert hasattr(request, '_jwt_cookie_reissue_revoked')
+    assert hasattr(request, "_jwt_cookie_reissue_revoked")
 
 
 def test_cookie_policy_custom_domain_list():
@@ -249,7 +253,7 @@ def test_insecure_cookie_policy():
     headers = policy.forget(request)
 
     _, cookie = headers[0]
-    chunks = cookie.split('; ')
+    chunks = cookie.split("; ")
 
     assert "secure" not in chunks
 
@@ -260,7 +264,7 @@ def test_insecure_cookie_policy():
     headers = policy.forget(request)
 
     _, cookie = headers[0]
-    chunks = cookie.split('; ')
+    chunks = cookie.split("; ")
 
     assert "secure" not in chunks
 
@@ -273,6 +277,6 @@ def test_cookie_policy_max_age():
     headers = policy.forget(request)
 
     _, cookie = headers[0]
-    chunks = cookie.split('; ')
+    chunks = cookie.split("; ")
 
     assert "Max-Age=10" not in chunks

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -196,7 +196,7 @@ def test_cookie_policy_creation():
 
 
 def test_cookie_policy_creation_fail():
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(ValueError) as e:
         JWTCookieAuthenticationPolicy.make_from(object())
 
     assert "Invalid policy type" in str(e.value)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -13,7 +13,7 @@ from pyramid.interfaces import IAuthenticationPolicy
 from pyramid_jwt.policy import (
     JWTAuthenticationPolicy,
     PyramidJSONEncoderFactory,
-    JWTTokenAuthenticationPolicy,
+    JWTCookieAuthenticationPolicy,
 )
 import uuid
 import pytest
@@ -187,7 +187,7 @@ def test_custom_json_encoder():
 def test_cookie_policy_creation():
     token_policy = JWTAuthenticationPolicy("secret")
     request = Request.blank("/")
-    cookie_policy = JWTTokenAuthenticationPolicy.make_from(token_policy)
+    cookie_policy = JWTCookieAuthenticationPolicy.make_from(token_policy)
 
     headers = cookie_policy.remember(request, "user")
 
@@ -197,13 +197,13 @@ def test_cookie_policy_creation():
 
 def test_cookie_policy_creation_fail():
     with pytest.raises(TypeError) as e:
-        JWTTokenAuthenticationPolicy.make_from(object())
+        JWTCookieAuthenticationPolicy.make_from(object())
 
     assert "Invalid policy type" in str(e.value)
 
 
 def test_cookie_policy_remember():
-    policy = JWTTokenAuthenticationPolicy("secret")
+    policy = JWTCookieAuthenticationPolicy("secret")
     request = Request.blank("/")
     headers = policy.remember(request, "user")
 
@@ -218,7 +218,7 @@ def test_cookie_policy_remember():
 
 
 def test_cookie_policy_forget():
-    policy = JWTTokenAuthenticationPolicy("secret")
+    policy = JWTCookieAuthenticationPolicy("secret")
     request = Request.blank("/")
     headers = policy.forget(request)
 
@@ -234,7 +234,7 @@ def test_cookie_policy_forget():
 
 
 def test_cookie_policy_custom_domain_list():
-    policy = JWTTokenAuthenticationPolicy("secret")
+    policy = JWTCookieAuthenticationPolicy("secret")
     request = Request.blank("/")
     domains = [request.domain, "other"]
     headers = policy.remember(request, "user", domains=domains)
@@ -248,7 +248,7 @@ def test_cookie_policy_custom_domain_list():
 
 
 def test_insecure_cookie_policy():
-    policy = JWTTokenAuthenticationPolicy("secret", https_only=False)
+    policy = JWTCookieAuthenticationPolicy("secret", https_only=False)
     request = Request.blank("/")
     headers = policy.forget(request)
 
@@ -259,7 +259,7 @@ def test_insecure_cookie_policy():
 
 
 def test_insecure_cookie_policy():
-    policy = JWTTokenAuthenticationPolicy("secret", https_only=False)
+    policy = JWTCookieAuthenticationPolicy("secret", https_only=False)
     request = Request.blank("/")
     headers = policy.forget(request)
 
@@ -272,7 +272,7 @@ def test_insecure_cookie_policy():
 @pytest.mark.freeze_time
 def test_cookie_policy_max_age():
     expiry = timedelta(seconds=10)
-    policy = JWTTokenAuthenticationPolicy("secret", expiration=expiry)
+    policy = JWTCookieAuthenticationPolicy("secret", expiration=expiry)
     request = Request.blank("/")
     headers = policy.forget(request)
 


### PR DESCRIPTION
These changes adds support for using JWT token on HttpOnly cookies.

Key benefits are:
- Cookies are usually dealt with automatically by browsers.
- Allow sliding sessions
- Still stateless: does not use server-side sessions

