### PR TITLE
docs: Fix simple typo, backens -> backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ JWT authentication for Pyramid
 
 This package implements an authentication policy for Pyramid that using  `JSON
 Web Tokens <http://jwt.io/>`_. This standard (`RFC 7519
-<https://tools.ietf.org/html/rfc7519>`_) is often used to secure backens APIs.
+<https://tools.ietf.org/html/rfc7519>`_) is often used to secure backend APIs.
 The excellent `PyJWT <https://pyjwt.readthedocs.org/en/latest/>`_ library is
 used for the JWT encoding / decoding logic.
 


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `backend` rather than `backens`.

