### PR TITLE
Configurable cookie path

### DIFF
--- a/src/pyramid_jwt/__init__.py
+++ b/src/pyramid_jwt/__init__.py
@@ -95,6 +95,7 @@ def set_jwt_cookie_authentication_policy(
     cookie_name=None,
     https_only=True,
     reissue_time=None,
+    path=None,
 ):
     settings = config.get_settings()
     cookie_name = cookie_name or settings.get("jwt.cookie_name")
@@ -121,6 +122,7 @@ def set_jwt_cookie_authentication_policy(
         cookie_name=cookie_name,
         https_only=https_only,
         reissue_time=reissue_time,
+        path=path,
     )
 
     _configure(config, auth_policy)

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -171,6 +171,7 @@ class JWTCookieAuthenticationPolicy(JWTAuthenticationPolicy):
         cookie_name=None,
         https_only=True,
         reissue_time=None,
+        path=None,
     ):
         super(JWTCookieAuthenticationPolicy, self).__init__(
             private_key,
@@ -199,7 +200,7 @@ class JWTCookieAuthenticationPolicy(JWTAuthenticationPolicy):
             secure=self.https_only,
             max_age=self.max_age,
             httponly=True,
-            path="/",
+            path=path,
         )
 
     @staticmethod

--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -199,7 +199,7 @@ class JWTCookieAuthenticationPolicy(JWTAuthenticationPolicy):
             secure=self.https_only,
             max_age=self.max_age,
             httponly=True,
-            path=None,
+            path="/",
         )
 
     @staticmethod


### PR DESCRIPTION
Makes the cookie's path configurable in the `set_jwt_cookie_authentication_policy` function. This allows the authentication endpoints to be at a different path than the endpoints to secure.