### PR TITLE
Implement capability for dual (cookie and haeder) authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,6 +237,13 @@ The follow options applies to the cookie-based authentication policy:
 |                |                           |               | instance) before a cookie (and the token   |
 |                |                           |               | within it) is reissued                     |
 +----------------+---------------------------+---------------+--------------------------------------------+
+| accept_header  | jwt.cookie_accept_header  |  False        | If cookie authentication doesn't return    |
+|                |                           |               | any claims, try to decode JWT header too   |
++----------------+---------------------------+---------------+--------------------------------------------+
+| header_first   | jwt.cookie_prefer_header  |  False        | Try to decode JWT header BEFORE decoding   |
+|                |                           |               | the cookie value. Set accept_header=True   |
+|                |                           |               | for this to take effect                    |
++----------------+---------------------------+---------------+--------------------------------------------+
 
 Pyramid JWT example use cases
 =============================

--- a/src/pyramid_jwt/__init__.py
+++ b/src/pyramid_jwt/__init__.py
@@ -96,6 +96,8 @@ def set_jwt_cookie_authentication_policy(
     https_only=True,
     reissue_time=None,
     cookie_path=None,
+    accept_header=None,
+    header_first=None,
 ):
     settings = config.get_settings()
     cookie_name = cookie_name or settings.get("jwt.cookie_name")
@@ -103,6 +105,10 @@ def set_jwt_cookie_authentication_policy(
     reissue_time = reissue_time or settings.get("jwt.cookie_reissue_time")
     if https_only is None:
         https_only = settings.get("jwt.https_only_cookie", True)
+    if accept_header is None:
+        accept_header = settings.get("jwt.cookie_accept_header", False)
+    if header_first is None:
+        header_first = settings.get("jwt.cookie_prefer_header", False)
 
     auth_policy = create_jwt_authentication_policy(
         config,


### PR DESCRIPTION
This patch provides a very direct way to stack cookie-only authentication and header authentication. Functionality is activated by accept_header/jwt.cookie_accept_header (parameter/ini-file value) and precedence is decided by header_first/jwt.cookie_prefer_header.