### PR TITLE
proposed strategy for integrating with pyramid_authstack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -470,3 +470,39 @@ could only access permissions with "reports". Obviously in our use case, one
 user had both "admin" and "reports" permissions, so they would be able to
 access any view regardless.
 
+Integrating with pyramid_authstack
+----------------------------------
+
+If you are using `pyramid_authstack <https://github.com/wichert/pyramid_authstack>`_
+and you need to add pyramid_jwt you can follow the example below:
+
+.. code-block:: python
+
+    from pyramid.authentication import AuthTktAuthenticationPolicy
+    from pyramid_authstack import AuthenticationStackPolicy
+    from pyramid_jwt import (
+        create_jwt_authentication_policy,
+        configure_jwt_authentication_policy
+    )
+
+    auth_policy = AuthenticationStackPolicy()
+    # Add an AuthTktAuthenticationPolicy
+    auth_policy.add_policy(
+        'ticket',
+        AuthTktAuthenticationPolicy('secret', timeout=60 * 60))
+    # Create a JWT authentication policy
+    jwt_policy = create_jwt_authentication_policy(config)
+    # configure the JWT policy -- this creates request property method jwt_claims
+    # and method create_jwt_token. We pass register=False so that the policy
+    # does not get registered, we will register the stack policy ourselves
+    configure_jwt_authentication_policy(config, jwt_policy, register=False)
+    auth_policy.add_policy('jwt', jwt_policy)
+    config.set_authentication_policy(auth_policy)
+
+Please bear in mind that ``request.jwt_claims`` will return an empty dictionary
+if the request was not authenticated using the JWT policy.
+
+You can similarly register a cookie-based JWT authentication policy using the
+function ``create_jwt_cookie_authentication_policy``. The same configuration
+function, ``configure_jwt_authentication_policy`` can be used with either policy
+type.

--- a/src/pyramid_jwt/__init__.py
+++ b/src/pyramid_jwt/__init__.py
@@ -8,7 +8,9 @@ from .policy import (
 def includeme(config):
     json_encoder_factory.registry = config.registry
     config.add_directive(
-        "set_jwt_authentication_policy", set_jwt_authentication_policy, action_wrap=True
+        "set_jwt_authentication_policy",
+        set_jwt_authentication_policy,
+        action_wrap=True,
     )
     config.add_directive(
         "set_jwt_cookie_authentication_policy",
@@ -60,27 +62,7 @@ def create_jwt_authentication_policy(
     )
 
 
-def _request_create_token(request, principal, expiration=None, audience=None, **claims):
-
-    return request.authentication_policy.create_token(
-        principal, expiration, audience, **claims
-    )
-
-
-def _request_claims(request):
-    return request.authentication_policy.get_claims(request)
-
-
-def _configure(config, auth_policy):
-    config.set_authentication_policy(auth_policy)
-    config.add_request_method(
-        lambda request: auth_policy, "authentication_policy", reify=True
-    )
-    config.add_request_method(_request_claims, "jwt_claims", reify=True)
-    config.add_request_method(_request_create_token, "create_jwt_token")
-
-
-def set_jwt_cookie_authentication_policy(
+def create_jwt_cookie_authentication_policy(
     config,
     private_key=None,
     public_key=None,
@@ -118,7 +100,7 @@ def set_jwt_cookie_authentication_policy(
         audience,
     )
 
-    auth_policy = JWTCookieAuthenticationPolicy.make_from(
+    return JWTCookieAuthenticationPolicy.make_from(
         auth_policy,
         cookie_name=cookie_name,
         https_only=https_only,
@@ -126,7 +108,58 @@ def set_jwt_cookie_authentication_policy(
         cookie_path=cookie_path,
     )
 
-    _configure(config, auth_policy)
+
+def configure_jwt_authentication_policy(config, auth_policy, register=True):
+    def _request_create_token(
+        request, principal, expiration=None, audience=None, **claims
+    ):
+        return auth_policy.create_token(principal, expiration, audience, **claims)
+
+    def _request_claims(request):
+        return auth_policy.get_claims(request)
+
+    config.add_request_method(_request_claims, "jwt_claims", reify=True)
+    config.add_request_method(_request_create_token, "create_jwt_token")
+
+    if register:
+        config.set_authentication_policy(auth_policy)
+
+
+def set_jwt_cookie_authentication_policy(
+    config,
+    private_key=None,
+    public_key=None,
+    algorithm=None,
+    expiration=None,
+    leeway=None,
+    http_header=None,
+    auth_type=None,
+    callback=None,
+    json_encoder=None,
+    audience=None,
+    cookie_name=None,
+    https_only=True,
+    reissue_time=None,
+    cookie_path=None,
+):
+    policy = create_jwt_cookie_authentication_policy(
+        config,
+        private_key,
+        public_key,
+        algorithm,
+        expiration,
+        leeway,
+        http_header,
+        auth_type,
+        callback,
+        json_encoder,
+        audience,
+        cookie_name,
+        https_only,
+        reissue_time,
+        cookie_path,
+    )
+    _configure(config, policy)
 
 
 def set_jwt_authentication_policy(


### PR DESCRIPTION
In relation to issue #53, this would be a first draft proposal for enabling integration with pyramid_authstack.

- rewritten _configure from __init.py__ to be consumed externally
- made the registration optional
- removed request property authentication_policy and turned _request_claims and _request_create_token into closures instead
- added create_jwt_cookie_authentication_policy with the same function as create_jwt_authentication_policy
- added example in the documentation