### PR TITLE
proposal for reissue callback and 3rd party token generation

### DIFF
--- a/src/pyramid_jwt/__init__.py
+++ b/src/pyramid_jwt/__init__.py
@@ -96,6 +96,7 @@ def set_jwt_cookie_authentication_policy(
     https_only=True,
     reissue_time=None,
     cookie_path=None,
+    reissue_callback=None,
 ):
     settings = config.get_settings()
     cookie_name = cookie_name or settings.get("jwt.cookie_name")
@@ -124,6 +125,7 @@ def set_jwt_cookie_authentication_policy(
         https_only=https_only,
         reissue_time=reissue_time,
         cookie_path=cookie_path,
+        reissue_callback=reissue_callback
     )
 
     _configure(config, auth_policy)

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -25,7 +25,8 @@ def test_interface():
 
 def test_cookie(dummy_request, principal):
     policy = JWTCookieAuthenticationPolicy("secret")
-    cookie = policy.remember(dummy_request, principal).pop()
+    token = policy.create_token(principal)
+    cookie = policy.remember(dummy_request, token).pop()
 
     assert len(cookie) == 2
 
@@ -36,7 +37,8 @@ def test_cookie(dummy_request, principal):
 
 def test_cookie_name(dummy_request, principal):
     policy = JWTCookieAuthenticationPolicy("secret", cookie_name="auth")
-    _, cookie = policy.remember(dummy_request, principal).pop()
+    token = policy.create_token(principal)
+    _, cookie = policy.remember(dummy_request, token).pop()
 
     name, value = cookie.split("=", 1)
     assert name == "auth"
@@ -45,7 +47,8 @@ def test_cookie_name(dummy_request, principal):
 def test_secure_cookie():
     policy = JWTCookieAuthenticationPolicy("secret", https_only=True)
     dummy_request = Request.blank("/")
-    _, cookie = policy.remember(dummy_request, str(uuid.uuid4())).pop()
+    token = policy.create_token(str(uuid.uuid4()))
+    _, cookie = policy.remember(dummy_request, token).pop()
 
     assert "; secure;" in cookie
     assert "; HttpOnly" in cookie
@@ -53,7 +56,8 @@ def test_secure_cookie():
 
 def test_insecure_cookie(dummy_request, principal):
     policy = JWTCookieAuthenticationPolicy("secret", https_only=False)
-    _, cookie = policy.remember(dummy_request, principal).pop()
+    token = policy.create_token(principal)
+    _, cookie = policy.remember(dummy_request, token).pop()
 
     assert "; secure;" not in cookie
     assert "; HttpOnly" in cookie
@@ -62,7 +66,8 @@ def test_insecure_cookie(dummy_request, principal):
 def test_cookie_decode(dummy_request, principal):
     policy = JWTCookieAuthenticationPolicy("secret", https_only=False)
 
-    header, cookie = policy.remember(dummy_request, principal).pop()
+    token = policy.create_token(principal)
+    header, cookie = policy.remember(dummy_request, token).pop()
     name, value = cookie.split("=", 1)
 
     value, _ = value.split(";", 1)
@@ -85,7 +90,8 @@ def test_cookie_max_age(dummy_request, principal):
 @pytest.mark.freeze_time
 def test_expired_token(dummy_request, principal, freezer):
     policy = JWTCookieAuthenticationPolicy("secret", cookie_name="auth", expiration=1)
-    _, cookie = policy.remember(dummy_request, principal).pop()
+    token = policy.create_token(principal)
+    _, cookie = policy.remember(dummy_request, token).pop()
     name, value = cookie.split("=", 1)
 
     freezer.tick(delta=2)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,7 +14,7 @@ def login_view(request):
 
 
 def login_cookie_view(request):
-    headers = remember(request, 1)
+    headers = remember(request, request.create_jwt_token(1))
     return Response(status=200, headers=headers, body="OK")
 
 


### PR DESCRIPTION
This covers issue #54 but also the ability to plumb the cookie authentication on top of a 3rd party token generation API. It's a significant API change so I'm looking for feedback on how to make this less invasive.

The documentation changes explain this PR in some detail.