### PR TITLE
fix exception when invalid cookie presented and cookie reissue enabled

### DIFF
--- a/src/pyramid_jwt/policy.py
+++ b/src/pyramid_jwt/policy.py
@@ -261,6 +261,10 @@ class JWTCookieAuthenticationPolicy(JWTAuthenticationPolicy):
 
         claims = self.jwt_decode(request, cookie)
 
+        # bypass reissue if cookie was invalid
+        if not claims:
+            return {}
+
         if reissue and not hasattr(request, "_jwt_cookie_reissued"):
             self._handle_reissue(request, claims)
         return claims

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -72,6 +72,20 @@ def test_cookie_decode(dummy_request, principal):
     assert claims["sub"] == principal
 
 
+def test_invalid_cookie_reissue(dummy_request, principal):
+    policy = JWTCookieAuthenticationPolicy("secret", https_only=False, reissue_time=10)
+
+    token = "invalid value"
+    header, cookie = policy.remember(dummy_request, token).pop()
+    name, value = cookie.split("=", 1)
+
+    value, _ = value.split(";", 1)
+    dummy_request.cookies = {name: value}
+
+    claims = policy.get_claims(dummy_request)
+    assert not claims
+
+
 def test_cookie_max_age(dummy_request, principal):
     policy = JWTCookieAuthenticationPolicy("secret", cookie_name="auth", expiration=100)
     _, cookie = policy.remember(dummy_request, principal).pop()


### PR DESCRIPTION
When the cookie is an invalid JWT token (corrupted, tempered with, expired, private key has changed, etc) and the cookie authentication policy has reissue_time set to a non-null value _handle_reissue throws exception ValueError("Cannot handle JWT reissue: insufficient arguments") because claims are empty.